### PR TITLE
[release/5.0] Use SupportedOSPlatforms property to generate assembly attributes

### DIFF
--- a/eng/targetframeworksuffix.props
+++ b/eng/targetframeworksuffix.props
@@ -4,12 +4,14 @@
       <PropertyGroup>
         <TargetsWindows>true</TargetsWindows>
         <PackageTargetRuntime>win</PackageTargetRuntime>
+        <SupportedOSPlatforms>windows</SupportedOSPlatforms>
       </PropertyGroup>
     </When>
     <When Condition="'$(TargetFrameworkSuffix)' == 'Unix'">
       <PropertyGroup>
         <TargetsUnix>true</TargetsUnix>
         <PackageTargetRuntime>unix</PackageTargetRuntime>
+        <SupportedOSPlatforms>unix</SupportedOSPlatforms>
       </PropertyGroup>
     </When>
     <When Condition="'$(TargetFrameworkSuffix)' == 'Linux'">
@@ -17,6 +19,7 @@
         <TargetsUnix>true</TargetsUnix>
         <TargetsLinux>true</TargetsLinux>
         <PackageTargetRuntime>linux</PackageTargetRuntime>
+        <SupportedOSPlatforms>unix;linux</SupportedOSPlatforms>
       </PropertyGroup>
     </When>
     <When Condition="'$(TargetFrameworkSuffix)' == 'Android'">
@@ -25,6 +28,7 @@
         <TargetsLinux>true</TargetsLinux>
         <TargetsAndroid>true</TargetsAndroid>
         <PackageTargetRuntime>android</PackageTargetRuntime>
+        <SupportedOSPlatforms>unix;linux;android</SupportedOSPlatforms>
       </PropertyGroup>
     </When>
     <When Condition="'$(TargetFrameworkSuffix)' == 'OSX'">
@@ -32,6 +36,7 @@
         <TargetsUnix>true</TargetsUnix>
         <TargetsOSX>true</TargetsOSX>
         <PackageTargetRuntime>osx</PackageTargetRuntime>
+        <SupportedOSPlatforms>unix;macos</SupportedOSPlatforms>
       </PropertyGroup>
     </When>
     <When Condition="'$(TargetFrameworkSuffix)' == 'tvOS'">
@@ -39,6 +44,7 @@
         <TargetsUnix>true</TargetsUnix>
         <TargetstvOS>true</TargetstvOS>
         <PackageTargetRuntime>tvos</PackageTargetRuntime>
+        <SupportedOSPlatforms>unix;tvos</SupportedOSPlatforms>
       </PropertyGroup>
     </When>
     <When Condition="'$(TargetFrameworkSuffix)' == 'iOS'">
@@ -46,6 +52,7 @@
         <TargetsUnix>true</TargetsUnix>
         <TargetsiOS>true</TargetsiOS>
         <PackageTargetRuntime>ios</PackageTargetRuntime>
+        <SupportedOSPlatforms>unix;ios</SupportedOSPlatforms>
       </PropertyGroup>
     </When>
     <When Condition="'$(TargetFrameworkSuffix)' == 'FreeBSD'">
@@ -53,6 +60,7 @@
         <TargetsUnix>true</TargetsUnix>
         <TargetsFreeBSD>true</TargetsFreeBSD>
         <PackageTargetRuntime>freebsd</PackageTargetRuntime>
+        <SupportedOSPlatforms>unix;freebsd</SupportedOSPlatforms>
       </PropertyGroup>
     </When>
     <When Condition="'$(TargetFrameworkSuffix)' == 'NetBSD'">
@@ -60,6 +68,7 @@
         <TargetsUnix>true</TargetsUnix>
         <TargetsNetBSD>true</TargetsNetBSD>
         <PackageTargetRuntime>netbsd</PackageTargetRuntime>
+        <SupportedOSPlatforms>unix</SupportedOSPlatforms>
       </PropertyGroup>
     </When>
     <When Condition="'$(TargetFrameworkSuffix)' == 'illumos'">
@@ -67,6 +76,7 @@
         <TargetsUnix>true</TargetsUnix>
         <TargetsIllumos>true</TargetsIllumos>
         <PackageTargetRuntime>illumos</PackageTargetRuntime>
+        <SupportedOSPlatforms>unix</SupportedOSPlatforms>
       </PropertyGroup>
     </When>
     <When Condition="'$(TargetFrameworkSuffix)' == 'Solaris'">
@@ -74,12 +84,14 @@
         <TargetsUnix>true</TargetsUnix>
         <TargetsSolaris>true</TargetsSolaris>
         <PackageTargetRuntime>solaris</PackageTargetRuntime>
+        <SupportedOSPlatforms>unix</SupportedOSPlatforms>
       </PropertyGroup>
     </When>
     <When Condition="'$(TargetFrameworkSuffix)' == 'Browser'">
       <PropertyGroup>
         <TargetsBrowser>true</TargetsBrowser>
         <PackageTargetRuntime>browser</PackageTargetRuntime>
+        <SupportedOSPlatforms>browser</SupportedOSPlatforms>
       </PropertyGroup>
     </When>
     <When Condition="'$(TargetFrameworkSuffix)' == ''">

--- a/eng/targetframeworksuffix.props
+++ b/eng/targetframeworksuffix.props
@@ -4,14 +4,12 @@
       <PropertyGroup>
         <TargetsWindows>true</TargetsWindows>
         <PackageTargetRuntime>win</PackageTargetRuntime>
-        <SupportedOSPlatforms>windows</SupportedOSPlatforms>
       </PropertyGroup>
     </When>
     <When Condition="'$(TargetFrameworkSuffix)' == 'Unix'">
       <PropertyGroup>
         <TargetsUnix>true</TargetsUnix>
         <PackageTargetRuntime>unix</PackageTargetRuntime>
-        <SupportedOSPlatforms>unix</SupportedOSPlatforms>
       </PropertyGroup>
     </When>
     <When Condition="'$(TargetFrameworkSuffix)' == 'Linux'">
@@ -19,7 +17,6 @@
         <TargetsUnix>true</TargetsUnix>
         <TargetsLinux>true</TargetsLinux>
         <PackageTargetRuntime>linux</PackageTargetRuntime>
-        <SupportedOSPlatforms>unix;linux</SupportedOSPlatforms>
       </PropertyGroup>
     </When>
     <When Condition="'$(TargetFrameworkSuffix)' == 'Android'">
@@ -28,7 +25,6 @@
         <TargetsLinux>true</TargetsLinux>
         <TargetsAndroid>true</TargetsAndroid>
         <PackageTargetRuntime>android</PackageTargetRuntime>
-        <SupportedOSPlatforms>unix;linux;android</SupportedOSPlatforms>
       </PropertyGroup>
     </When>
     <When Condition="'$(TargetFrameworkSuffix)' == 'OSX'">
@@ -36,7 +32,6 @@
         <TargetsUnix>true</TargetsUnix>
         <TargetsOSX>true</TargetsOSX>
         <PackageTargetRuntime>osx</PackageTargetRuntime>
-        <SupportedOSPlatforms>unix;macos</SupportedOSPlatforms>
       </PropertyGroup>
     </When>
     <When Condition="'$(TargetFrameworkSuffix)' == 'tvOS'">
@@ -44,7 +39,6 @@
         <TargetsUnix>true</TargetsUnix>
         <TargetstvOS>true</TargetstvOS>
         <PackageTargetRuntime>tvos</PackageTargetRuntime>
-        <SupportedOSPlatforms>unix;tvos</SupportedOSPlatforms>
       </PropertyGroup>
     </When>
     <When Condition="'$(TargetFrameworkSuffix)' == 'iOS'">
@@ -52,7 +46,6 @@
         <TargetsUnix>true</TargetsUnix>
         <TargetsiOS>true</TargetsiOS>
         <PackageTargetRuntime>ios</PackageTargetRuntime>
-        <SupportedOSPlatforms>unix;ios</SupportedOSPlatforms>
       </PropertyGroup>
     </When>
     <When Condition="'$(TargetFrameworkSuffix)' == 'FreeBSD'">
@@ -60,7 +53,6 @@
         <TargetsUnix>true</TargetsUnix>
         <TargetsFreeBSD>true</TargetsFreeBSD>
         <PackageTargetRuntime>freebsd</PackageTargetRuntime>
-        <SupportedOSPlatforms>unix;freebsd</SupportedOSPlatforms>
       </PropertyGroup>
     </When>
     <When Condition="'$(TargetFrameworkSuffix)' == 'NetBSD'">
@@ -68,7 +60,6 @@
         <TargetsUnix>true</TargetsUnix>
         <TargetsNetBSD>true</TargetsNetBSD>
         <PackageTargetRuntime>netbsd</PackageTargetRuntime>
-        <SupportedOSPlatforms>unix</SupportedOSPlatforms>
       </PropertyGroup>
     </When>
     <When Condition="'$(TargetFrameworkSuffix)' == 'illumos'">
@@ -76,7 +67,6 @@
         <TargetsUnix>true</TargetsUnix>
         <TargetsIllumos>true</TargetsIllumos>
         <PackageTargetRuntime>illumos</PackageTargetRuntime>
-        <SupportedOSPlatforms>unix</SupportedOSPlatforms>
       </PropertyGroup>
     </When>
     <When Condition="'$(TargetFrameworkSuffix)' == 'Solaris'">
@@ -84,14 +74,12 @@
         <TargetsUnix>true</TargetsUnix>
         <TargetsSolaris>true</TargetsSolaris>
         <PackageTargetRuntime>solaris</PackageTargetRuntime>
-        <SupportedOSPlatforms>unix</SupportedOSPlatforms>
       </PropertyGroup>
     </When>
     <When Condition="'$(TargetFrameworkSuffix)' == 'Browser'">
       <PropertyGroup>
         <TargetsBrowser>true</TargetsBrowser>
         <PackageTargetRuntime>browser</PackageTargetRuntime>
-        <SupportedOSPlatforms>browser</SupportedOSPlatforms>
       </PropertyGroup>
     </When>
     <When Condition="'$(TargetFrameworkSuffix)' == ''">

--- a/eng/versioning.targets
+++ b/eng/versioning.targets
@@ -22,20 +22,18 @@
     </AssemblyMetadata>
   </ItemGroup>
 
-  <!-- Adds SupportedOSPlatform attribute for Windows Specific libraries -->
-  <ItemGroup Condition="'$(IsWindowsSpecific)' == 'true' and '$(IsTestProject)' != 'true'">
-    <AssemblyAttribute Include="System.Runtime.Versioning.SupportedOSPlatform">
-        <_Parameter1>windows</_Parameter1>
-    </AssemblyAttribute>
-  </ItemGroup>
-
-  <ItemGroup>
+  <!-- Adds SupportedOSPlatform or UnsupportedOSPlatform attributes -->
+  <ItemGroup Condition="'$(IsTestProject)' != 'true'">
+    <_supportedOSPlatforms Include="$(SupportedOSPlatforms)" />
     <_unsupportedOSPlatforms Include="$(UnsupportedOSPlatforms)" />
   </ItemGroup>
 
-  <Target Name="AddUnsupportedOSPlatformAttribute" BeforeTargets="GenerateAssemblyInfo" AfterTargets="PrepareForBuild">
+  <Target Name="AddAssemblyOSPlatformAttributes" BeforeTargets="GenerateAssemblyInfo" AfterTargets="PrepareForBuild">
     <ItemGroup>
-      <AssemblyAttribute Include="System.Runtime.Versioning.UnsupportedOSPlatform" Condition="'@(_unsupportedOSPlatforms)' != ''">
+      <AssemblyAttribute Include="System.Runtime.Versioning.SupportedOSPlatform" Condition="'@(_supportedOSPlatforms)' != ''">
+        <_Parameter1>%(_supportedOSPlatforms.Identity)</_Parameter1>
+      </AssemblyAttribute>
+      <AssemblyAttribute Include="System.Runtime.Versioning.UnsupportedOSPlatform" Condition="'@(_supportedOSPlatforms)' == '' and '@(_unsupportedOSPlatforms)' != ''">
         <_Parameter1>%(_unsupportedOSPlatforms.Identity)</_Parameter1>
       </AssemblyAttribute>
     </ItemGroup>

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -245,7 +245,7 @@
 
   <!-- Adds System.Runtime.Versioning*Platform* annotation attributes to < .NET 5 builds -->
   <Choose>
-    <When Condition="('$(IncludePlatformAttributes)' == 'true' or '$(IsWindowsSpecific)' == 'true') and ('$(TargetFrameworkIdentifier)' != '.NETCoreApp' or $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '5.0')))">
+    <When Condition="('$(IncludePlatformAttributes)' == 'true' or '$(SupportedOSPlatforms)' != '' or '$(UnsupportedOSPlatforms)' != '') and ('$(TargetFrameworkIdentifier)' != '.NETCoreApp' or $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '5.0')))">
       <ItemGroup>
         <Compile Include="$(CoreLibSharedDir)System\Runtime\Versioning\PlatformAttributes.cs" Link="System\Runtime\Versioning\PlatformAttributes.cs" />
       </ItemGroup>

--- a/src/libraries/Microsoft.Extensions.Logging.EventLog/src/Microsoft.Extensions.Logging.EventLog.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.EventLog/src/Microsoft.Extensions.Logging.EventLog.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <EnableDefaultItems>true</EnableDefaultItems>
-    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/Microsoft.Extensions.Logging.EventLog/src/Microsoft.Extensions.Logging.EventLog.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.EventLog/src/Microsoft.Extensions.Logging.EventLog.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <EnableDefaultItems>true</EnableDefaultItems>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/Microsoft.Win32.Registry.AccessControl/Directory.Build.props
+++ b/src/libraries/Microsoft.Win32.Registry.AccessControl/Directory.Build.props
@@ -2,6 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/Microsoft.Win32.Registry/Directory.Build.props
+++ b/src/libraries/Microsoft.Win32.Registry/Directory.Build.props
@@ -2,6 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/Microsoft.Win32.SystemEvents/Directory.Build.props
+++ b/src/libraries/Microsoft.Win32.SystemEvents/Directory.Build.props
@@ -2,6 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Open</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Data.OleDb/Directory.Build.props
+++ b/src/libraries/System.Data.OleDb/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Diagnostics.EventLog/Directory.Build.props
+++ b/src/libraries/System.Diagnostics.EventLog/Directory.Build.props
@@ -2,6 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Open</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Diagnostics.PerformanceCounter/Directory.Build.props
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/Directory.Build.props
@@ -2,6 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Open</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.DirectoryServices.AccountManagement/Directory.Build.props
+++ b/src/libraries/System.DirectoryServices.AccountManagement/Directory.Build.props
@@ -6,6 +6,6 @@
          to a different assembly. -->
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>ECMA</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.DirectoryServices/Directory.Build.props
+++ b/src/libraries/System.DirectoryServices/Directory.Build.props
@@ -6,6 +6,6 @@
          to a different assembly. -->
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.IO.FileSystem.AccessControl/Directory.Build.props
+++ b/src/libraries/System.IO.FileSystem.AccessControl/Directory.Build.props
@@ -2,6 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.IO.Pipes.AccessControl/Directory.Build.props
+++ b/src/libraries/System.IO.Pipes.AccessControl/Directory.Build.props
@@ -2,6 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Management/Directory.Build.props
+++ b/src/libraries/System.Management/Directory.Build.props
@@ -6,6 +6,6 @@
          to a different assembly. -->
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Net.Http.WinHttpHandler/Directory.Build.props
+++ b/src/libraries/System.Net.Http.WinHttpHandler/Directory.Build.props
@@ -2,6 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Net.Sockets/Directory.Build.props
+++ b/src/libraries/System.Net.Sockets/Directory.Build.props
@@ -3,5 +3,6 @@
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IncludePlatformAttributes>true</IncludePlatformAttributes>
+    <UnsupportedOSPlatforms Condition="'$(TargetsWindows)' != 'true'">browser</UnsupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Net.Sockets/Directory.Build.props
+++ b/src/libraries/System.Net.Sockets/Directory.Build.props
@@ -3,6 +3,5 @@
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <IncludePlatformAttributes>true</IncludePlatformAttributes>
-    <UnsupportedOSPlatforms Condition="'$(TargetsWindows)' != 'true'">browser</UnsupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Security.AccessControl/Directory.Build.props
+++ b/src/libraries/System.Security.AccessControl/Directory.Build.props
@@ -2,6 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Security.Cryptography.Cng/Directory.Build.props
+++ b/src/libraries/System.Security.Cryptography.Cng/Directory.Build.props
@@ -2,6 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Security.Cryptography.ProtectedData/Directory.Build.props
+++ b/src/libraries/System.Security.Cryptography.ProtectedData/Directory.Build.props
@@ -2,6 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Security.Principal.Windows/Directory.Build.props
+++ b/src/libraries/System.Security.Principal.Windows/Directory.Build.props
@@ -2,6 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.ServiceProcess.ServiceController/Directory.Build.props
+++ b/src/libraries/System.ServiceProcess.ServiceController/Directory.Build.props
@@ -2,6 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Threading.AccessControl/Directory.Build.props
+++ b/src/libraries/System.Threading.AccessControl/Directory.Build.props
@@ -2,6 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Threading.Overlapped/Directory.Build.props
+++ b/src/libraries/System.Threading.Overlapped/Directory.Build.props
@@ -2,6 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>
 </Project>

--- a/src/libraries/System.Windows.Extensions/Directory.Build.props
+++ b/src/libraries/System.Windows.Extensions/Directory.Build.props
@@ -2,6 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Open</StrongNameKeyId>
-    <IsWindowsSpecific>true</IsWindowsSpecific>
+    <SupportedOSPlatforms>windows</SupportedOSPlatforms>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
In preparation for taking in the [Platform Compatibility Analyzer](https://github.com/dotnet/roslyn-analyzers/pull/3917), we need to address build errors that will be introduced by the analyzer due to our `[SupportedOSPlatform]` and `[UnsupportedOSPlatform]` annotations.

This **Draft PR** uses an MSBuild-based approach similar to what was put in place for `<UnsupportedOSPlatforms>` such that assembly-level attributes can be generated based on the platforms listed in that property; a `<SupportedOSPlatforms>` property is introduced that works the same way. This approach will prevent supported and unsupported combinations in assembly attributes.

This is applied against the `release/5.0` branch.  The effects on the generated `AssemblyInfo.cs` files across the entire build are illustrated in https://github.com/jeffhandley/supportedosplatforms/pull/3.

The PR for the `master` branch is https://github.com/dotnet/runtime/pull/41209.