### PR TITLE
Alt: Treat filtered-enumeration ERROR_FILE_NOT_FOUND as no matches (#130134)

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEnumerator.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEnumerator.Windows.cs
@@ -183,6 +183,16 @@ namespace System.IO.Enumeration
                 default:
                     int error = (int)Interop.NtDll.RtlNtStatusToDosError(status);
 
+                    // A filtered NtQueryDirectoryFile that matches nothing surfaces as different NTSTATUS values
+                    // depending on the file system driver (STATUS_NO_SUCH_FILE on NTFS, STATUS_OBJECT_NAME_NOT_FOUND
+                    // on the Azure App Service run-from-package zip mount, etc.), all of which translate to
+                    // ERROR_FILE_NOT_FOUND. The directory handle was already opened, so treat that as no matches.
+                    if (error == Interop.Errors.ERROR_FILE_NOT_FOUND)
+                    {
+                        DirectoryFinished();
+                        return false;
+                    }
+
                     // Note that there are many NT status codes that convert to ERROR_ACCESS_DENIED.
                     if ((error == Interop.Errors.ERROR_ACCESS_DENIED && _options.IgnoreInaccessible) || ContinueOnError(error))
                     {


### PR DESCRIPTION
## Summary

**Alternative approach** for `dotnet/runtime#130134` (zero-match `Directory.GetFiles` throws `FileNotFoundException` on the Azure App Service run-from-package zip mount; regression from `dotnet/runtime#127974`).

See the primary/recommended approach in the peer PR from `jeffhandley/directory-getfiles-status-object`.

## Root cause

`dotnet/runtime#127974` passes the search pattern to `NtQueryDirectoryFile` as an OS-level filter. A filtered query that matches zero entries returns `STATUS_NO_SUCH_FILE` (`0xC000000F`) on NTFS but `STATUS_OBJECT_NAME_NOT_FOUND` (`0xC0000034`) on the zip mount; only the former is handled, so the latter throws.

## Change (this branch)

In `FileSystemEnumerator<T>.GetData()` (Windows), the `default` case already translates the `NTSTATUS` to a Win32 error via `RtlNtStatusToDosError`. This change treats `ERROR_FILE_NOT_FOUND` as an empty result (before the access-denied / `ContinueOnError` checks). Both `0xC000000F` and `0xC0000034` translate to `ERROR_FILE_NOT_FOUND`, so this handles the zip mount **and** any other driver whose zero-match status maps to file-not-found.

**Trade-off vs. the recommended approach:** broader — it keys off the translated Win32 error rather than an explicit `NTSTATUS`, so it could in principle absorb a file-not-found produced for a different reason.

## Validation

Validated with the same faithful `NtQueryDirectoryFile` repro harness: on the .NET 11 branch, the zero-match probe returns empty (was throwing) while a matching pattern still returns results.

> [!NOTE]
> This pull request (including its description) was created by GitHub Copilot.
