### PR TITLE
Alt: Fall back to unfiltered enumeration on STATUS_OBJECT_NAME_NOT_FOUND (#130134)

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEnumerator.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEnumerator.Windows.cs
@@ -161,6 +161,26 @@ namespace System.IO.Enumeration
                     ReturnSingleEntry: Interop.BOOLEAN.FALSE,
                     FileName: fileNamePtr,
                     RestartScan: Interop.BOOLEAN.FALSE);
+
+                // Some file system drivers don't handle the OS-level FileName filter the way NTFS does and report a
+                // zero-match first call as STATUS_OBJECT_NAME_NOT_FOUND (notably the Azure App Service run-from-package
+                // zip mount). Rather than special-casing each such status, fall back to the original behavior for this
+                // directory: re-run the query without the filter and let the managed matching (which always runs) filter.
+                if (fileNamePtr != null && (uint)status == Interop.StatusOptions.STATUS_OBJECT_NAME_NOT_FOUND)
+                {
+                    status = Interop.NtDll.NtQueryDirectoryFile(
+                        FileHandle: _directoryHandle,
+                        Event: IntPtr.Zero,
+                        ApcRoutine: IntPtr.Zero,
+                        ApcContext: IntPtr.Zero,
+                        IoStatusBlock: &statusBlock,
+                        FileInformation: _buffer,
+                        Length: (uint)_bufferLength,
+                        FileInformationClass: Interop.NtDll.FILE_INFORMATION_CLASS.FileFullDirectoryInformation,
+                        ReturnSingleEntry: Interop.BOOLEAN.FALSE,
+                        FileName: null,
+                        RestartScan: Interop.BOOLEAN.TRUE);
+                }
             }
 
             switch ((uint)status)


### PR DESCRIPTION
## Summary

**Alternative approach** for `dotnet/runtime#130134` (zero-match `Directory.GetFiles` throws `FileNotFoundException` on the Azure App Service run-from-package zip mount; regression from `dotnet/runtime#127974`).

See the primary/recommended approach in the peer PR from `jeffhandley/directory-getfiles-status-object`.

## Root cause

`dotnet/runtime#127974` passes the search pattern to `NtQueryDirectoryFile` as an OS-level filter. A filtered query that matches zero entries returns `STATUS_NO_SUCH_FILE` (`0xC000000F`) on NTFS but `STATUS_OBJECT_NAME_NOT_FOUND` (`0xC0000034`) on the zip mount; only the former is handled, so the latter throws.

## Change (this branch)

In `FileSystemEnumerator<T>.GetData()` (Windows), when the first **filtered** `NtQueryDirectoryFile` call returns `STATUS_OBJECT_NAME_NOT_FOUND`, re-issue the query with **no** `FileName` filter and `RestartScan`, reverting to the pre-`#127974` behavior for that directory (enumerate everything, then filter in managed code — which always runs anyway). The empty result is then produced without throwing.

**Trade-off vs. the recommended approach:** behavior-preserving and also guards drivers that reject otherwise-valid filters, but adds an extra syscall on the affected path and is more code.

## Validation

Validated with the same faithful `NtQueryDirectoryFile` repro harness: on the .NET 11 branch, the zero-match probe returns empty with `count = 0` (was throwing) while a matching pattern still returns `count = 1`.

> [!NOTE]
> This pull request (including its description) was created by GitHub Copilot.
